### PR TITLE
fix warning when using pipelined command

### DIFF
--- a/lib/sidekiq/paquet/bundle.rb
+++ b/lib/sidekiq/paquet/bundle.rb
@@ -7,9 +7,9 @@ module Sidekiq
         args = item.fetch('args'.freeze, [])
 
         Sidekiq.redis do |conn|
-          conn.multi do
-            conn.zadd('bundles'.freeze, 0, worker_name)
-            conn.rpush("bundle:#{worker_name}", Sidekiq.dump_json(args))
+          conn.multi do |pipeline|
+            pipeline.zadd('bundles'.freeze, 0, worker_name)
+            pipeline.rpush("bundle:#{worker_name}", Sidekiq.dump_json(args))
           end
         end
       end


### PR DESCRIPTION
This fixes this warning:

```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.multi do
  redis.get("key")
end

should be replaced by

redis.multi do |pipeline|
  pipeline.get("key")
end

(called from /home/maxime/kolsquare_redis/sidekiq-paquet/lib/sidekiq/paquet/bundle.rb:10:in `block in append'}
```